### PR TITLE
Create a common method filesystem_handling.remove_objectives

### DIFF
--- a/nc-backup-py/compression/compression.py
+++ b/nc-backup-py/compression/compression.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     if command_compression.OBJECTIVES:
         sys.path.append(command_compression.HOME_FOLDER)
         from execution.subprocess_execution import SubprocessExecution
-        from tools.filesystem_handling import FilesystemHandling
+        from tools.filesystem_handling import FilesystemHandling, remove_objectives
         from execution.config_parser import ConfigParser
 
         execute = False
@@ -101,7 +101,5 @@ if __name__ == "__main__":
         print 'OBJECTIVES and DESTINATION need to be present in compression module, execution will not continue'
         exit(1)
 
-    if command_compression.REMOVE_OBJECTIVES == True or command_compression.REMOVE_OBJECTIVES == 'True':
-        print 'Deleting files after objective files as per config option --REMOVE_OBJECTIVES: ' \
-              + command_compression.OBJECTIVES
-        FilesystemHandling.remove_files(command_compression.OBJECTIVES)
+    remove_objectives(command_compression.OBJECTIVES,
+                      command_compression.REMOVE_OBJECTIVES)

--- a/nc-backup-py/conf/conf.json
+++ b/nc-backup-py/conf/conf.json
@@ -5,7 +5,7 @@
     "LOCAL_BACKUP": "/opt/backup/local",
     "HOME_FOLDER": "/var/lib/nc-backup-py/",
     "LOG_FOLDER": "/var/log/nc-backup-py/nc-backup-py.log",
-    "MESSAGE_CONFIG_COMMAND": "https://backupreporter.yourdomain.com/backup_service.php",
+    "MESSAGE_CONFIG_COMMAND": "https://backupreporter.service.chinanetcloud.com/backup_report_service/backup_service.php",
     "MESSAGE_CONFIG_METHOD": "post",
     "__Methods": "post|e-mail|sms|wechat,etc"
   },
@@ -13,17 +13,27 @@
     "ACTION": "execute",
     "NAME": "filesbackup",
     "PARAMETERS": {
-      "FILESET_INCLUDE": "/etc /var/spool/cron",
+      "FILESET_INCLUDE": "/etc",
       "FILESET_EXCLUDE": ""
     }
   },
   "COMPRESSION": {
     "ACTION": "execute",
-    "NAME": "compression"
+    "NAME": "compression",
+    "PARAMETERS": {
+      "TARGETS": "/opt/backup/files",
+      "DESTINATION":"/opt/backup/compressed",
+      "REMOVE_TARGETS": "True"
+    }
   },
   "ENCRYPTION": {
     "ACTION": "execute",
-    "NAME": "encryption"
+    "NAME": "encryption",
+    "PARAMETERS": {
+      "TARGETS": "/opt/backup/compressed",
+      "DESTINATION":"/opt/backup/encrypted",
+      "REMOVE_TARGETS": "True"
+    }
   },
   "SIZE": {
     "ACTION": "load",
@@ -32,6 +42,15 @@
     "CLASS": "SizeCalculation",
     "PARAMETERS": {
       "TARGETS": "/opt/backup/encrypted"
+    }
+  },
+  "STORAGE_LOCAL": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"local",
+      "TARGETS": "/opt/backup/encrypted",
+      "REMOVE_TARGETS": "True"
     }
   }
 }

--- a/nc-backup-py/encryption/encryption.py
+++ b/nc-backup-py/encryption/encryption.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
     # Dynamic imporst using HOME_FOLDER as default value.
     sys.path.append(encryption_command.HOME_FOLDER)
     from execution.subprocess_execution import SubprocessExecution
-    from tools.filesystem_handling import FilesystemHandling
+    from tools.filesystem_handling import FilesystemHandling, remove_objectives
     from execution.config_parser import ConfigParser
 
     # Validate some Parameters and pass default values if absent
@@ -239,12 +239,8 @@ if __name__ == "__main__":
                         EncryptionWorks.split_file(EncryptionWorks(), file_encrypted, encryption_command.FILE_SIZE)
                         FilesystemHandling.remove_files(out_file_str)
 
-        # Compressed file is not a directory.
-        if not ConfigParser.check_exists(ConfigParser(), encryption_command.REMOVE_OBJECTIVES) \
-                or encryption_command.REMOVE_OBJECTIVES == 'True' or  encryption_command.REMOVE_OBJECTIVES == True:
-            print 'Deleting files after objective files as per config option --REMOVE_OBJECTIVES: ' \
-                  + encryption_command.OBJECTIVES
-            FilesystemHandling.remove_files(encryption_command.OBJECTIVES)
+        remove_objectives(encryption_command.OBJECTIVES,
+                          encryption_command.REMOVE_OBJECTIVES)
 
     # Decryption
     elif encryption_command.DECRYPT == '-d' or encryption_command.DECRYPT is True:

--- a/nc-backup-py/storage/storage.py
+++ b/nc-backup-py/storage/storage.py
@@ -43,7 +43,7 @@ class StorageExecution:
 if __name__ == "__main__":
     storage_cmd = StorageExecution.storage_commands(StorageExecution())
     sys.path.append(storage_cmd.HOME_FOLDER)
-    from tools.filesystem_handling import FilesystemHandling
+    from tools.filesystem_handling import FilesystemHandling, remove_objectives
     from execution.subprocess_execution import SubprocessExecution
     from execution.config_parser import ConfigParser
     if str(storage_cmd.DESTINATION) not in ['s3', 'oss', 'ssh', 'local', 'azure']:
@@ -56,11 +56,10 @@ if __name__ == "__main__":
         storage_cmd.OBJECTIVES = '/opt/backup/encrypted'
     print 'Executing backup files type: ' + storage_cmd.DESTINATION
     if storage_cmd.DESTINATION == 'local':
-        command_move = 'mv ' + storage_cmd.OBJECTIVES + '/* ' + storage_cmd.LOCAL_BACKUP
+        command_move = 'cp ' + storage_cmd.OBJECTIVES + '/* ' + storage_cmd.LOCAL_BACKUP
         FilesystemHandling.create_directory(storage_cmd.LOCAL_BACKUP)
         ExecuteBackup = SubprocessExecution.main_execution_function(SubprocessExecution(), command_move)
-        if storage_cmd.REMOVE_OBJECTIVES == 'True':
-            FilesystemHandling.remove_files(storage_cmd.OBJECTIVES)
+        remove_objectives(storage_cmd.OBJECTIVES, storage_cmd.REMOVE_OBJECTIVES)
     elif storage_cmd.DESTINATION == 's3':
         print "calling S3 storage upload functions"
         from storages import AWSS3

--- a/nc-backup-py/tools/filesystem_handling.py
+++ b/nc-backup-py/tools/filesystem_handling.py
@@ -12,11 +12,21 @@ class FilesystemHandling:
             # SubprocessExecution.print_output(SubprocessExecution(), execution_mkdir)
 
     @staticmethod
-    def remove_files(remove_objectives):
+    def remove_files(objectives):
         try:
-            delete_command = 'rm -rf ' + remove_objectives
+            delete_command = 'rm -rf ' + objectives
             execution_message = SubprocessExecution.main_execution_function(SubprocessExecution(), delete_command)
-            # SubprocessExecution.print_output(SubprocessExecution(), execution_message)
+            return SubprocessExecution.print_output(SubprocessExecution(), execution_message)
         except Exception as e:
             e.args += (execution_message,)
             raise
+
+
+def remove_objectives(objectives, remove_objectives):
+    """Check if REMOVE_OBJECTIVES is True and call remove_files."""
+    if remove_objectives in ['True', 'true', 'TRUE', True, None, '']:
+        print('Config option --REMOVE_OBJECTIVES set to True ')
+        print('Deleting files %s' % remove_objectives)
+        print(FilesystemHandling.remove_files(objectives))
+    else:
+        print('REMOVE_TARGETS not set to True.')


### PR DESCRIPTION
Create a common method filesystem_handling.remove_objectives to remove objectives. By default remove objectives unless specified.