### PR TITLE
Dev qingcloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you think the project is useful or has potential, please add a star.
 
 
 
-## Quick Start # Change this after setup is done
+## Quick Start
 
 This quick start is to download, install and configure the `master` branch to upload files to AWS S3.
 
@@ -33,27 +33,27 @@ See [INSTALLATION](docs/INSTALLATION.md) for more information on customizing you
 See [CONFIGURATION](docs/CONFIGURATION_FILE.md) to view and configure all available features.
 
 * Clone or Download the git repository and change directory .
-  ```
+  ```bash
   $ git clone https://github.com/ChinaNetCloud/nc-backup-py.git
   $ cd nc-backup-py
   ```
 
   or
 
-  ```
+  ```bash
   $ wget -O nc-backup-py.zip https://github.com/ChinaNetCloud/nc-backup-py/archive/master.zip
   $ unzip nc-backup-py.zip
   $ cd nc-backup-py-master
   ```
 
 * Run setup
-  ```
+  ```bash
   $ sudo pip install --upgrade .
   ```
 
   or, after installing the required dependencies using pip
 
-  ```
+  ```bash
   $ sudo python setup.py
   ```
 
@@ -62,12 +62,12 @@ See [CONFIGURATION](docs/CONFIGURATION_FILE.md) to view and configure all availa
   This quick start works for uploading you local files to AWS S3. See [CONFIGURATION](docs/CONFIGURATION.md) for a complete guide and documentation.
 
   1. Change hostname to your hostname.
-    ```
+    ```bash
     "HOSTNAME": "srv-your-hostname"
     ```
 
   2. Change the AWS S3 bucket name.
-    ```
+    ```bash
     "BUCKET_NAME": "your-bucket-name"
     ```
 
@@ -80,7 +80,7 @@ See [CONFIGURATION](docs/CONFIGURATION_FILE.md) to view and configure all availa
       - Configure - See [Quick Configuration](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-quick-configuration)
 
       - Please switch user to `ncbackup` before configuring AWS CLI
-        ```
+        ```bash
         # su - ncbackup -s /bin/bash
         $ whoami && pwd
         ncbackup
@@ -97,11 +97,22 @@ See [CONFIGURATION](docs/CONFIGURATION_FILE.md) to view and configure all availa
 
 
 * Execute Backup manually
-```
+```bash
 $ sudo -u ncbackup python /var/lib/nc-backup-py/backup.py -r -c /etc/nc-backup-py/conf.json -l WARNING
 ```
+
+* Copy and save your key file.
+
+  The first time you run your backup script with **ENCRYPTION** enabled, it will create a key at `/etc/nc-backup-py/key_file`. Please copy this and store it in a secure location. (ex: keepass) You will require this to decrypt the files later.
+
+  ```bash
+  # ls /etc/nc-backup-py/key_file
+  # cat /etc/nc-backup-py/key_file
+  ```
+
+
 * Optionally add a cronjob
-```
+```bash
 $ crontab -eu ncbackup
 00 03 * * * python /var/lib/nc-backup-py/backup.py -r -c /etc/nc-backup-py/conf.json
 ```
@@ -111,7 +122,7 @@ $ crontab -eu ncbackup
 ## Decryption
 
 Download the files to /opt/backup e.g.:
-```
+```bash
 $ aws s3 cp s3://cnc-bj-backup/srv-nc-bj-zabbix-qa1/20160705_042923.tar.gz.crypt.000 /opt/backup
 # Execute the decryption command:
 # For a encrypted archive "20160705_042923.tar.gz.crypt.000"
@@ -124,31 +135,35 @@ $ python /var/lib/nc-backup-py/encryption/encryption.py -d \
 --HOME_FOLDER "/var/lib/nc-backup-py"
 ```
 
-For more information on decryption, go to the decryption section
+For more information see [decryption](docs/DECRYPTION.md)
 
 ## Uninstall
 
-```
+```bash
 pip uninstall nc-backup-py
 ```
-* To remove scripts and sudo access
-```
+* To remove scripts
+```bash
 sudo rm -rf /var/lib/nc-backup-py/
 ```
 * To remove ncbackup user
-```
+```bash
 sudo userdel ncbackup && /etc/sudoers.d/ncbackup
 ```
-* To remove logs
+* To remove sudo access.
+```bash
+rm -rf /etc/sudoers.d/ncbackup
 ```
+* To remove logs
+```bash
 sudo rm -rf /var/log/nc-backup-py
 ```
 * To remove configuration
-```
+```bash
 sudo rm -rf /etc/nc-backup-py
 ```
 * To remove all
-```
+```bash
 pip uninstall nc-backup-py
 sudo rm -rf /var/lib/nc-backup-py/ /etc/nc-backup-py/ /var/log/nc-backup-py/
 sudo userdel ncbackup && rm -rf /etc/sudoers.d/ncbackup

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -238,70 +238,10 @@ Regarding the optional end required parameters the same could be exported to the
 ```
 Notice: Out standard for the configurations has changed so now all the configuration files have to be in /etc/nc-backup-py/ in this case the key file will be in /etc/nc-backup-py/key_file.
 
-#### Storage
-#####Local backup
-```
-     "STORAGE_LOCAL": {
-        "ACTION": "execute",
-        "NAME": "storage",
-        "PARAMETERS":{
-          "DESTINATION":"local",
-          "TARGETS": "/opt/backup/encrypted"
-        }
-    }
-```
+#### Storage Configuration
 
-##### AWS s3
-```
-     "STORAGE": {
-        "ACTION": "execute",
-        "NAME": "storage",
-        "PARAMETERS":{
-          "TARGETS": "/opt/backup/encrypted",
-          "DESTINATION":"s3",
-          "BUCKET_NAME": "cncbackup",
-          "UPLOAD_COMMAND": "aws s3 cp",
-          "REMOVE_TARGETS": "True"
-        }
-    }
-```
-This section is to store the backup, in this case s3. S3 is the only current backend implemented, but the script is supposed to support various backends including OSS, SSH, etc.
+[CONFIGURATION](docs/STORAGE.md) for instructions on how to configure storage and install related 3rd party tools.
 
-##### Aliyun OSS
-```
-     "STORAGE_OSS": {
-        "ACTION": "execute",
-        "NAME": "storage",
-        "PARAMETERS":{
-          "TARGETS": "/Users/cncuser/Downloads/backup/encrypted",
-          "DESTINATION":"oss",
-          "BUCKET_NAME": "cncbackup",
-          "ALIYUN_CREDENTIALS": "/etc/.alioss.conf",
-          "REMOVE_TARGETS": "True"
-        }
-    }
-```
-##### Combine storages
-```
-    "STORAGE_LOCAL": {
-    "ACTION": "execute",
-    "NAME": "storage",
-    "PARAMETERS":{
-      "DESTINATION":"local",
-      "TARGETS": "/opt/backup/encrypted"
-    }
-    },
-    "STORAGE": {
-        "ACTION": "execute",
-        "NAME": "storage",
-        "PARAMETERS":{
-          "DESTINATION":"s3",
-          "BUCKET_NAME": "bucketname",
-          "TARGETS": "/opt/backup/local",
-          "REMOVE_TARGETS": "False"
-        }
-    }
-```
 ##### QA
 ```
       "QA":{
@@ -318,37 +258,6 @@ This feature is still under development in test conceptual phase, the idea is fo
 Q: Does the AWS CLI validate checksums?
 The AWS CLI will perform checksum validation for uploading and downloading files in specific scenarios. Upload The AWS CLI will calculate and auto-populate the Content-MD5 header for both standard and multipart uploads. If the checksum that S3 calculates does not match the Content-MD5 provided, S3 will not store the object and instead will return an error message back the AWS CLI. The AWS CLI will retry this error up to 5 times before giving up. On the case that any files fail to transfer successfully to S3, the AWS CLI will exit with a non zero RC. See aws help returncodes for more information. Taken from AWS CLI FAQ
 
-## How to decrypt
-
-###if the server doing backups has python 2.7
-
-The encryption script is the same script used for decription. Is should be user as follows:
-
-`python encryption/encryption.py -d --KEY_FILE "conf/key_file" --OBJECTIVES "/path/to/file/name" --DESTINATION "/path/where/the/resulting/will/be" --HOME_FOLDER "/path/to/nc-backup-py"`
-
-`-d`: is to say we are decrypting.
-`--KEY_FILE "conf/key_file"`: is to indicate the path to the keyfile to used for decryption.
-`--OBJECTIVES "/path/to/file(s)"`: It's to say where are the encrypted files to be decrypted. if the download is more than one file they need to have names that start with the same partern; the software asumes you mean wild card (*) at the end. In other words, the names should be like something like this filename.tar.gz.crypt.000, filename.tar.gz.crypt.001, filename.tar.gz.crypt.00N, so in this case yout path should contanin the common part's of the name "filename.tar.gz.crypt.00".
-`--DESTINATION "path/and/name/of/tar.gz/file"`: this is the name and path that you want the resulting file to have after decryption
-`--HOME_FOLDER "/path/to/source/code/nc-backup-py"`: this is for the encryption script to know where the whole backups software is installed.
-
-Example for a single file:
-
-`python /var/lib/nc-backup-py/encryption/encryption.py -d --KEY_FILE "/etc/nc-backup-py/key_file" --OBJECTIVES "/opt/backup/20160705_042923.tar.gz.crypt.000" --DESTINATION "/opt/backup/20160705_042923.tar.gz" --HOME_FOLDER "/var/lib/nc-backup-py"`
-
-Example for multiple files:
-
-`python /vagrant/nc-backup-py/encryption/encryption.py -d --KEY_FILE "/vagrant/nc-backup-py/conf/key_file" --OBJECTIVES "/opt/backup/20160607_161750.tar.gz.crypt.00" --DESTINATION "/opt/backup/20160607_161750.tar.gz" --HOME_FOLDER "/vagrant/nc-backup-py"`
-
-Notice: The only difference to decrypt one or more than one file is in the name of --OBJECTIVES. The first example show the whole path and the second example shows only the path with the part of the name that is common.
-
-After this you have to untar the file using something like this:
-
-`tar -xvf /opt/backup/20160607_161750.tar.gz /opt/backup/`
-
-Idea: We might want develop a feature in the near future called "restore" that would do all the work for you and give you back the files already decompressed. This feature could even log information to BRT about the Restore job, and use dates, etc
-
-### if the server doing backups has python 2.6
 
 # NOTICE: Add MATERIS
 Use the same method as weth ncbackup bash script: https://wiki.service.chinanetcloud.com/wiki/Operations:NC-OP_TP-782-How_to_restore_GPG_encrypt_backup_files

--- a/docs/DECRYPTION.md
+++ b/docs/DECRYPTION.md
@@ -1,0 +1,48 @@
+## How to decrypt
+
+###if the server doing backups has python 2.7
+
+The encryption script `/var/lib/nc-backup-py/encryption/encryption.py` is the same script used for decryption.
+
+Example for a single file:
+
+Download the files to /opt/backup/restore e.g.:
+```
+$ mkdir -p /opt/backup/restore # If /opt/backup/restore is not present
+$ aws s3 cp s3://cnc-bj-backup/srv-nc-bj-zabbix-qa1/20160705_042923.tar.gz.crypt.000 /opt/backup/restore
+# Execute the decryption command:
+# For a encrypted archive "20160705_042923.tar.gz.crypt.000"
+$ ls
+$ 20160705_042923.tar.gz.crypt.000
+$ python /var/lib/nc-backup-py/encryption/encryption.py -d \
+--KEY_FILE "/etc/nc-backup-py/key_file" \
+--OBJECTIVES "20171106_105027.tar.gz.crypt.000" \
+--DESTINATION "20171106_105027.tar.gz" \
+--HOME_FOLDER "/var/lib/nc-backup-py"
+```
+
+
+If the encrypted file has been split into multiple parts, point to the common name `20171106_105027.tar.gz.crypt`
+
+`20171106_105027.tar.gz.crypt` will match all 4 files in the below example.
+
+```
+$ ls /opt/backup/restore
+20171106_105027.tar.gz.crypt.000
+20171106_105027.tar.gz.crypt.001
+20171106_105027.tar.gz.crypt.002
+20171106_105027.tar.gz.crypt.003
+$ python /var/lib/nc-backup-py/encryption/encryption.py -d \
+--KEY_FILE "/etc/nc-backup-py/key_file" \
+--OBJECTIVES "20171106_105027.tar.gz.crypt" \ #
+--DESTINATION "20171106_105027.tar.gz" \
+--HOME_FOLDER "/var/lib/nc-backup-py"
+```
+
+Notice: The only difference to decrypt one or more than one file is in the name of --OBJECTIVES. The first example show the whole path and the second example shows only the path with the part of the name that is common.
+
+After this you have to untar the file using something like this:
+
+`tar -xvf /opt/backup/20160607_161750.tar.gz /opt/backup/`
+
+Idea: We might want develop a feature in the near future called "restore" that would do all the work for you and give you back the files already decompressed. This feature could even log information to BRT about the Restore job, and use dates, etc

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -1,5 +1,154 @@
 
-## Using Amazon S3
+## Storage Configuration
+
+All upload commands are run using templates at "nc-backup-py/storage/storage_templates.json".
+
+Templates for local, oss, s3, scp and rsync are available in the package. It is possible to configure the script to run any bash command. See Custom Command Example below.
+
+Multiple storage options can be configured into one.
+
+### Local backup
+```json
+  "STORAGE_LOCAL": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION": "local",
+      "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+      "REMOVE_TARGETS": "True"
+    }
+  }
+```
+
+### AWS s3
+
+Add the below section to `/etc/nc-backup-py/conf.json` and
+
+See [Using Amazon S3](###Using-Amazon-S3) below for how to setup awscli.
+```json
+  "STORAGE_OSS": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"oss",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
+    }
+},
+```
+This section is to store the backup, in this case s3. S3 is the only current backend implemented, but the script is supposed to support various backends including OSS, SSH, etc.
+
+### Aliyun OSS
+
+Add the below section to `/etc/nc-backup-py/conf.json` and
+
+See [Using Aliyun Object Storage Services](###Using-Aliyun-Object-Storage-Services) for how to setup alicmd.
+
+```json
+  "STORAGE_OSS": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"oss",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+```
+
+### Customized storage
+
+Customized storages can be defined using **Named placeholders** feature of python.
+
+For example the `aws s3` cli command is defined as follows in the file [storage_templates.json](nc-backup-py/storage/storage_templates.json)
+
+```json
+  "UPLOAD_COMMAND_TEMPLATE": "aws s3 cp %(OBJECTIVES)s/%(file)s s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
+  "UPLOAD_COMMAND_DICT": "{'BUCKET': 'ncbackup'}",
+```
+
+Use UPLOAD_COMMAND_TEMPLATE to define your upload command and use UPLOAD_COMMAND_DICT to set variables.
+
+Behind the hood, the shell command is created as follows.
+
+```python
+UPLOAD_COMMAND_DICT['HOSTNAME'] = HOSTNAME
+UPLOAD_COMMAND_DICT['OBJECTIVES'] = OBJECTIVES
+
+for file in os.listdir("OBJECTIVES")
+  UPLOAD_COMMAND_DICT['file'] = "%s/file" % OBJECTIVES
+  UPLOAD_COMMAND_TEMPLATE % UPLOAD_COMMAND_DICT
+  ... execute command ...
+```
+
+For example, the `aws s3 cp` can be used as below to upload to ncbackup.
+
+```json
+"STORAGE_CUSTOM": {
+  "ACTION": "execute",
+  "NAME": "storage",
+  "PARAMETERS":{
+    "DESTINATION":"custom_command",
+    "OBJECTIVES": "/opt/backup/encrypted",
+    "UPLOAD_COMMAND_TEMPLATE": "aws s3 cp %(OBJECTIVES)s/%(file)s s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
+    "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+    "__READTHIS": "Use UPLOAD_COMMAND_TEMPLATE to create your custom command.",
+    "__READTHIS1": "ARGS_DICT to pass variables to your custom upload command",
+    "REMOVE_TARGETS": "False"
+    }
+  },
+```
+
+### Combine storages
+
+```json
+  "STORAGE_S3": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"s3",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+  "STORAGE_OSS": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"oss",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+  "STORAGE_LOCAL": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION": "local",
+      "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+      "REMOVE_TARGETS": "True"
+    }
+  }
+```
+
+## Setup 3rd party clients.
+
+Instructions on how to setup 3rd party clients are given below.
+
+### Using Amazon S3
 
   * AWS CLI
 
@@ -8,7 +157,7 @@
     - Configure - See [Quick Configuration](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-quick-configuration)
 
     - Please switch user to `ncbackup` before configuring AWS CLI
-      ```
+      ```bash
       # su - ncbackup -s /bin/bash
       $ whoami && pwd
       ncbackup
@@ -23,7 +172,7 @@
   * AWS roles
     - See [IAM Roles for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
-## Using Aliyun Object Storage Services
+### Using Aliyun Object Storage Services
 
   * To upload backups to Aliyun OSS install aliyun-oss-tools.
   aliyun-oss-tools
@@ -46,7 +195,7 @@
 
     Before you configure, please make sure you check if this server can access Aliyun OSS using private address. The difference is that if the server can access Aliyun using private address the traffic is considered internal therefore it's FREE. If you use public addresses the customer is charged for this traffic. this amount is changed as per daily backup, so it could be a lot if there is a lot of information to backup.
 
-  ```
+  ```bash
   # alicmd --config
   You will see some contents like below
   [INFO]: Start to config AliYun Open Storage Service.
@@ -60,7 +209,7 @@
   ```
 
   * Edit the alioss config file.
-  ```
+  ```bash
   vim /etc/.alioss.conf ;`
   [options]
   retry_times = 15
@@ -69,7 +218,7 @@
 
   * Verify OSS Configuration file:
 
-  ```
+  ```bash
   # alicmd --show
   XXcloud 2012-06-19T07:05:33.000Z  # Should list all buckets we have`
   ```

--- a/nc-backup-py/conf/Examples/conf.bak.json
+++ b/nc-backup-py/conf/Examples/conf.bak.json
@@ -106,26 +106,37 @@
       "OBJECTIVES": "/opt/backup/encrypted"
     }
   },
-  "STORAGE": {
+  "STORAGE_S3": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
-      "OBJECTIVES": "/opt/backup/encrypted",
       "DESTINATION":"s3",
-      "BUCKET_NAME": "cncbackup",
-      "UPLOAD_COMMAND": "aws s3 cp",
-      "REMOVE_OBJECTIVES": "True"
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+      "REMOVE_TARGETS": "False"
     }
   },
   "STORAGE_OSS": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
-      "OBJECTIVES": "/Users/cncuser/Downloads/backup/encrypted",
       "DESTINATION":"oss",
-      "BUCKET_NAME": "cncbackup",
-      "ALIYUN_CREDENTIALS": "/etc/.alioss.conf",
-      "REMOVE_OBJECTIVES": "True"
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+  "STORAGE_LOCAL": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION": "local",
+      "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+      "REMOVE_TARGETS": "True"
     }
   },
   "CLEANUP":{

--- a/nc-backup-py/conf/Examples/conf.centos6.json
+++ b/nc-backup-py/conf/Examples/conf.centos6.json
@@ -71,28 +71,36 @@
       "OBJECTIVES": "/opt/test/encrypted"
     }
   },
-  "STORAGE": {
+  "STORAGE_S3": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
-      "OBJECTIVES": "/opt/test/encrypted",
       "DESTINATION":"s3",
-      "__options": "local,s3,ssh,oss",
-      "REMOVE_OBJECTIVES": "True",
-      "BUCKET_NAME": "cncbackup",
-      "UPLOAD_COMMAND": "/usr/bin/aws s3 cp"
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+      "REMOVE_TARGETS": "False"
     }
   },
-  "STORAGE_ALIL": {
+  "STORAGE_OSS": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
-      "OBJECTIVES": "/opt/test/encrypted",
       "DESTINATION":"oss",
-      "__options": "local,s3,ssh,oss",
-      "REMOVE_OBJECTIVES": "True",
-      "BUCKET_NAME": "cncbackup",
-      "UPLOAD_COMMAND": "/usr/bin/aws s3 cp"
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
     }
-  }
+  },
+  "STORAGE_LOCAL": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION": "local",
+      "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+      "REMOVE_TARGETS": "True"
+    }
 }

--- a/nc-backup-py/conf/Examples/conf.centos61.json
+++ b/nc-backup-py/conf/Examples/conf.centos61.json
@@ -27,12 +27,36 @@
       "TARGETS": "/opt/backup/encrypted"
     }
   },
-  "STORAGE": {
+  "STORAGE_S3": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
       "DESTINATION":"s3",
-      "BUCKET_NAME": "cncbackup"
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+      "REMOVE_TARGETS": "False"
     }
-  }
+  },
+  "STORAGE_OSS": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"oss",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+  "STORAGE_LOCAL": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION": "local",
+      "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+      "REMOVE_TARGETS": "True"
+    }
 }

--- a/nc-backup-py/conf/Examples/conf.custom_command.json
+++ b/nc-backup-py/conf/Examples/conf.custom_command.json
@@ -44,24 +44,49 @@
       "TARGETS": "/opt/backup/encrypted"
     }
   },
+  "STORAGE_S3": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"s3",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+  "STORAGE_OSS": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"oss",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
+    }
+  },
   "STORAGE_CUSTOM": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
       "DESTINATION":"custom_command",
       "OBJECTIVES": "/opt/backup/encrypted",
-      "CUSTOM_COMMAND_TEMPLATE": "aws s3 cp %(OBJECTIVES)s/%(file)s s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
-      "CUSTOM_COMMAND_DICT": "{'BUCKET': 'ncbackup'}",
+      "UPLOAD_COMMAND_TEMPLATE": "examplecmd cp %(OBJECTIVES)s/%(file)s s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
+      "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+      "__READTHIS": "Use UPLOAD_COMMAND_TEMPLATE to create your custom command.",
+      "__READTHIS1": "ARGS_DICT to pass variables to your custom upload command",
       "REMOVE_TARGETS": "False"
-    }
-  },
+    },
   "STORAGE_LOCAL": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
       "DESTINATION": "local",
       "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
       "REMOVE_TARGETS": "True"
-    }
+    },
   }
 }

--- a/nc-backup-py/conf/Examples/conf.mysql.json
+++ b/nc-backup-py/conf/Examples/conf.mysql.json
@@ -35,12 +35,25 @@
       "TARGETS": "/opt/backup/encrypted"
     }
   },
-  "STORAGE": {
+  "STORAGE_S3": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
       "DESTINATION":"s3",
-      "BUCKET_NAME": "cncbackup"
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'BUCKET': 'ncbackup'}",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+  "STORAGE_LOCAL": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION": "local",
+      "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+      "REMOVE_TARGETS": "True"
     }
   }
 }

--- a/nc-backup-py/conf/Examples/conf.oss.json
+++ b/nc-backup-py/conf/Examples/conf.oss.json
@@ -31,11 +31,12 @@
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
-      "OBJECTIVES": "/opt/backup/encrypted",
       "DESTINATION":"oss",
-      "BUCKET_NAME": "chinanetcloud",
-      "ALIYUN_CREDENTIALS": "/etc/.alioss.conf",
-      "REMOVE_OBJECTIVES": "True"
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
     }
   }
 }

--- a/nc-backup-py/conf/conf.json.dist
+++ b/nc-backup-py/conf/conf.json.dist
@@ -2,10 +2,9 @@
   "GENERAL": {
     "HOSTNAME": "srv-nc-template-host-config",
     "WORK_FOLDER": "/opt/backup",
-    "LOCAL_BACKUP": "/opt/backup/local",
     "HOME_FOLDER": "/var/lib/nc-backup-py/",
     "LOG_FOLDER": "/var/log/nc-backup-py/nc-backup-py.log",
-    "MESSAGE_CONFIG_COMMAND": "https://backupreporter.service.chinanetcloud.com/backup_report_service/backup_service.php",
+    "MESSAGE_CONFIG_COMMAND": "https://backupreporter.service.yourdomain.com/backup_report_service/backup_service.php",
     "MESSAGE_CONFIG_METHOD": "post",
     "__Methods": "post|e-mail|sms|wechat,etc"
   },
@@ -44,12 +43,38 @@
       "TARGETS": "/opt/backup/encrypted"
     }
   },
+  "STORAGE_S3": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"s3",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'BUCKET': 'yourbucket'}",
+      "__READTHIS": "Use awscli and configure s3 access keys.",
+      "REMOVE_TARGETS": "False"
+    }
+  },
+  "STORAGE_OSS": {
+    "ACTION": "execute",
+    "NAME": "storage",
+    "PARAMETERS":{
+      "DESTINATION":"oss",
+      "ACTION": "upload",
+      "OBJECTIVES": "/opt/backup/encrypted",
+      "ARGS_DICT": "{}",
+      "__READTHIS": "Use alicmd -c to configure oss access and bucket.",
+      "REMOVE_TARGETS": "False"
+    }
+  },
   "STORAGE_LOCAL": {
     "ACTION": "execute",
     "NAME": "storage",
     "PARAMETERS":{
-      "DESTINATION":"local",
+      "DESTINATION": "local",
       "TARGETS": "/opt/backup/encrypted",
+      "ARGS_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+      "__READTHIS": "The above path is where your local backups will be stored.",
       "REMOVE_TARGETS": "True"
     }
   }

--- a/nc-backup-py/storage/storage.py
+++ b/nc-backup-py/storage/storage.py
@@ -7,10 +7,38 @@ class StorageExecution:
         """Initalize and run."""
         import sys
         import os
-        print "os.getcwd(): %s" % os.getcwd()
+        import json
+
+        # print "os.getcwd(): %s" % os.getcwd()
+
         self.storage_cmd = self.get_args()
-        self.set_defaults()
+
         sys.path.append(self.storage_cmd.HOME_FOLDER)
+
+        # from pprint import pprint
+        # pprint(self.storage_cmd)
+
+        # Load storage_templates.json
+        template_path = os.path.join(
+            self.storage_cmd.HOME_FOLDER,
+            self.storage_cmd.DEFAULT_TEMPLATE_FILE
+        )
+        with open(template_path, 'r') as f:
+            self.templates = json.load(f)
+        # pprint(self.templates)
+
+        if self.storage_cmd.ACTION.lower() == "upload":
+            self.upload_content()
+        elif self.storage_cmd.ACTION.lower() == "remove":
+            self.remove_content()
+        elif self.storage_cmd.ACTION.lower() == "list":
+            self.list_content()
+        elif self.storage_cmd.ACTION.lower() == "size":
+            self.check_size_content()
+        else:
+            print "ACTION %s is not defined." % self.storage_cmd.ACTION
+            print "Available actions are UPLOAD, REMOVE, LIST, SIZE"
+            exit(1)
 
     def get_args(self):
         """Get arguments to script."""
@@ -23,10 +51,22 @@ class StorageExecution:
             required=False
             )
         parser_object.add_argument(
+            '-w', '--WORK_FOLDER',
+            type=str,
+            help='Backup working directory.',
+            required=False
+            )
+        parser_object.add_argument(
             '-D', '--DESTINATION',
             type=str,
             help='Backup destination: local, s3, oss, etc',
             required=True)
+        parser_object.add_argument(
+            '-A', '--ACTION',
+            type=str,
+            help='Storage Action: upload, list or remove.',
+            required=False,
+            default='Upload')
         parser_object.add_argument(
             '-H', '--HOME_FOLDER',
             type=str,
@@ -62,18 +102,44 @@ class StorageExecution:
             '--ARGS_DICT',
             type=str,
             help='ARGS Dictionary',
-            required=False)
+            required=False,
+            default="{}")
         parser_object.add_argument(
-            '--DEFAULTS_FILE',
+            '--DEFAULT_TEMPLATE_FILE',
             type=str,
             help='Default Templates File',
             required=False,
-            default="storage_templates.json")
+            default="storage/storage_templates.json")
         args_list, unknown = parser_object.parse_known_args()
         return args_list
 
-    def set_defaults(self):
-        """Set defaults if not present."""
+    def iterate_result(self, uploads_to_cloud):
+        succesful = 0
+        count_file = 1
+        print uploads_to_cloud
+        for upload_to_cloud in uploads_to_cloud:
+            if upload_to_cloud[0] is not 0:
+                print 'upload of file number ' + str(
+                    count_file) + ' failed to upload.'
+                exit(1)
+            count_file = count_file + 1
+
+    def execute(self):
+        print "calling %s command to upload." % self.storage_cmd.DESTINATION
+        from storages import Storage
+        command = Storage(self.storage_cmd)
+        command_output = command.execute()
+        if command_output:
+            StorageExecution.iterate_result(StorageExecution(), command_output)
+        else:
+            print 'Executing %s retuned a None result' % self.storage_cmd.DESTINATION
+
+    def list_content(self):
+        """Set defaults for list if not present."""
+        print "Listing directory content"
+
+    def upload_content(self):
+        """Set defaults for upload_command if not present."""
         if not self.storage_cmd.REMOVE_OBJECTIVES:
             self.storage_cmd.REMOVE_OBJECTIVES = 'True'
             print "WARNING: REMOVE_OBJECTIVES is missing, default is true."
@@ -91,31 +157,19 @@ class StorageExecution:
                 print '<add link to docs>'
                 exit(1)
             else:
+                self.storage_cmd.UPLOAD_COMMAND_TEMPLATE = self.templates[self.storage_cmd.DESTINATION]['UPLOAD_COMMAND_TEMPLATE']
                 print "Sucessfully set Upload command template for %s." % self.storage_cmd.DESTINATION
 
-    def iterate_resut(self, uploads_to_cloud):
-        succesful = 0
-        count_file = 1
-        print uploads_to_cloud
-        for upload_to_cloud in uploads_to_cloud:
-            if upload_to_cloud[0] is not 0:
-                print 'upload of file number ' + str(
-                    count_file) + ' failed to upload.'
-                exit(1)
-            count_file = count_file + 1
+    def remove_content(self):
+        """Set defaults for remove if not present."""
+        print 'General: removing files from storage'
 
-    def execute_upload(self):
-        print "calling %s command to upload." % self.storage_cmd.DESTINATION
-        from storages import Storage
-        custom_command_upload = Storage(self.storage_cmd)
-        custom_uploads = custom_command_upload.execute()
-        if custom_uploads:
-            StorageExecution.iterate_resut(StorageExecution(), custom_uploads)
-        else:
-            print 'Executing %s upload retuned a None result' % self.storage_cmd.DESTINATION
+    def check_size_content(self):
+        """Set defaults for size if not present."""
+        print 'checking the files size'
 
 
 if __name__ == "__main__":
 
     executor = StorageExecution()
-    executor.execute_upload()
+    executor.execute()

--- a/nc-backup-py/storage/storage.py
+++ b/nc-backup-py/storage/storage.py
@@ -1,37 +1,97 @@
-import argparse
-import sys
-
+"""Storage Execution Classes."""
 
 
 class StorageExecution:
 
-    def storage_commands(self):
+    def __init__(self):
+        """Initalize and run."""
+        import sys
+        import os
+        print "os.getcwd(): %s" % os.getcwd()
+        self.storage_cmd = self.get_args()
+        self.set_defaults()
+        sys.path.append(self.storage_cmd.HOME_FOLDER)
+
+    def get_args(self):
+        """Get arguments to script."""
+        import argparse
         parser_object = argparse.ArgumentParser()
-        parser_object.add_argument('-o', '--OBJECTIVES', '--TARGETS', type=str
-                                   , help='Objectives to encrypt', required=False)
-        parser_object.add_argument('-l', '--LOCAL_BACKUP', type=str
-                                   , help='Objectives to encrypt', required=True)
-        parser_object.add_argument('-H', '--HOME_FOLDER', type=str
-                                   , help='Path to the whole project folder, '
-                                          'to include other libruaries', required=True)
-        parser_object.add_argument('-D', '--DESTINATION', type=str
-                                   , help='Backup destination: local, s3, oss, etc', required=True)
-        parser_object.add_argument('-b', '--BUCKET_NAME', type=str
-                                   , help='Backup destination e.g: nc-backup-kr', required=False)
-        parser_object.add_argument('-hn', '--HOSTNAME', type=str
-                                   , help='Server name (client Host Name) e.g: nc-backup-kr', required=True)
-        parser_object.add_argument('-u', '--UPLOAD_COMMAND', type=str
-                                   , help='AWS upload command', required=False)
-        parser_object.add_argument('-R', '--REMOVE_OBJECTIVES', '--REMOVE_TARGETS', type=str
-                                   , help='Remove Encrypted files and folder after execution', required=False)
-        parser_object.add_argument('-A', '--ALIYUN_CREDENTIALS', type=str
-                                   , help='Remove Encrypted files and folder', required=False)
-        parser_object.add_argument('--CUSTOM_COMMAND_TEMPLATE', type=str
-                                   , help='Custom Command Template', required=False)
-        parser_object.add_argument('--CUSTOM_COMMAND_DICT', type=str
-                                   , help='Custom Command Dictionary', required=False)
+        parser_object.add_argument(
+            '-o', '--OBJECTIVES', '--TARGETS',
+            type=str,
+            help='Objectives to encrypt',
+            required=False
+            )
+        parser_object.add_argument(
+            '-D', '--DESTINATION',
+            type=str,
+            help='Backup destination: local, s3, oss, etc',
+            required=True)
+        parser_object.add_argument(
+            '-H', '--HOME_FOLDER',
+            type=str,
+            help='Path to the nc-backup-py folder',
+            required=True)
+        parser_object.add_argument(
+            '-hn', '--HOSTNAME',
+            type=str,
+            help='Server name (client Host Name) e.g: nc-backup-kr',
+            required=True)
+        parser_object.add_argument(
+            '-u', '--UPLOAD_COMMAND_TEMPLATE',
+            type=str,
+            help='Upload command template.',
+            required=False)
+        parser_object.add_argument(
+            '-l', '--LS_COMMAND_TEMPLATE',
+            type=str,
+            help='List Command Template',
+            required=False)
+        parser_object.add_argument(
+            '-r', '--RM_COMMAND_TEMPLATE',
+            type=str,
+            help='List Command Template',
+            required=False)
+        parser_object.add_argument(
+            '-R', '--REMOVE_OBJECTIVES',
+            '--REMOVE_TARGETS',
+            type=str,
+            help='Remove Encrypted files and folder after execution',
+            required=False)
+        parser_object.add_argument(
+            '--ARGS_DICT',
+            type=str,
+            help='ARGS Dictionary',
+            required=False)
+        parser_object.add_argument(
+            '--DEFAULTS_FILE',
+            type=str,
+            help='Default Templates File',
+            required=False,
+            default="storage_templates.json")
         args_list, unknown = parser_object.parse_known_args()
         return args_list
+
+    def set_defaults(self):
+        """Set defaults if not present."""
+        if not self.storage_cmd.REMOVE_OBJECTIVES:
+            self.storage_cmd.REMOVE_OBJECTIVES = 'True'
+            print "WARNING: REMOVE_OBJECTIVES is missing, default is true."
+        if not self.storage_cmd.OBJECTIVES:
+            self.storage_cmd.OBJECTIVES = '/opt/backup/encrypted'
+        print 'Storage Destination: ' + self.storage_cmd.DESTINATION
+
+        if self.storage_cmd.UPLOAD_COMMAND_TEMPLATE:
+            print "Using template %s " % self.storage_cmd.UPLOAD_COMMAND_TEMPLATE
+        else:
+            print "Trying to set default %s storage upload functions" % self.storage_cmd.DESTINATION
+            if str(self.storage_cmd.DESTINATION) not in ['s3', 'oss', 'ssh', 'local']:
+                print ('Upload command template for not available storage destination: %s ' % self.storage_cmd.DESTINATION)
+                print 'You can use your own template for the upload command. See:'
+                print '<add link to docs>'
+                exit(1)
+            else:
+                print "Sucessfully set Upload command template for %s." % self.storage_cmd.DESTINATION
 
     def iterate_resut(self, uploads_to_cloud):
         succesful = 0
@@ -44,60 +104,18 @@ class StorageExecution:
                 exit(1)
             count_file = count_file + 1
 
-if __name__ == "__main__":
-    storage_cmd = StorageExecution.storage_commands(StorageExecution())
-    sys.path.append(storage_cmd.HOME_FOLDER)
-    from tools.filesystem_handling import FilesystemHandling, remove_objectives
-    from execution.subprocess_execution import SubprocessExecution
-    from execution.config_parser import ConfigParser
-    if str(storage_cmd.DESTINATION) not in ['s3', 'oss', 'ssh', 'local', 'azure', 'custom_command']:
-        print 'Not supported storage destination: ' + str(storage_cmd.DESTINATION)
-        exit(1)
-
-    if not ConfigParser.check_exists(ConfigParser(), storage_cmd.REMOVE_OBJECTIVES):
-        storage_cmd.REMOVE_OBJECTIVES = 'True'
-    if not ConfigParser.check_exists(ConfigParser(), storage_cmd.OBJECTIVES):
-        storage_cmd.OBJECTIVES = '/opt/backup/encrypted'
-    print 'Executing backup files type: ' + storage_cmd.DESTINATION
-    if storage_cmd.DESTINATION == 'local':
-        command_move = 'cp ' + storage_cmd.OBJECTIVES + '/* ' + storage_cmd.LOCAL_BACKUP
-        FilesystemHandling.create_directory(storage_cmd.LOCAL_BACKUP)
-        ExecuteBackup = SubprocessExecution.main_execution_function(SubprocessExecution(), command_move)
-        remove_objectives(storage_cmd.OBJECTIVES, storage_cmd.REMOVE_OBJECTIVES)
-    elif storage_cmd.DESTINATION == 's3':
-        print "calling S3 storage upload functions"
-        from storages import AWSS3
-        uploads_to_s3 = AWSS3.upload_content(AWSS3(storage_cmd.HOME_FOLDER),storage_cmd.OBJECTIVES,
-                                            storage_cmd.BUCKET_NAME, storage_cmd.HOSTNAME,
-                                            storage_cmd.UPLOAD_COMMAND, storage_cmd.REMOVE_OBJECTIVES)
-        succesful = 0
-        count_file = 1
-        if uploads_to_s3:
-            StorageExecution.iterate_resut(StorageExecution(), uploads_to_s3)
-        else:
-            print 'Executing OSS upload retuned a None result'
-
-    elif storage_cmd.DESTINATION == 'oss':
-        print "calling OSS storage upload functions"
-        from storages import AliyunOSS
-        print storage_cmd.BUCKET_NAME
-        uploads_to_oss = AliyunOSS.upload_content(AliyunOSS(storage_cmd.HOME_FOLDER), storage_cmd.ALIYUN_CREDENTIALS,
-                                                  storage_cmd.OBJECTIVES, storage_cmd.BUCKET_NAME,
-                                                  storage_cmd.HOSTNAME, storage_cmd.REMOVE_OBJECTIVES)
-        if uploads_to_oss:
-            StorageExecution.iterate_resut(StorageExecution(), uploads_to_oss)
-        else:
-            print 'Executing OSS upload retuned a None result'
-
-    elif storage_cmd.DESTINATION == 'ssh':
-        print "calling SSH storage upload functions"
-
-    elif storage_cmd.DESTINATION == 'custom_command':
-        print "calling custom command to upload."
-        from storages import CustomCommand
-        custom_command_upload = CustomCommand(storage_cmd)
+    def execute_upload(self):
+        print "calling %s command to upload." % self.storage_cmd.DESTINATION
+        from storages import Storage
+        custom_command_upload = Storage(self.storage_cmd)
         custom_uploads = custom_command_upload.execute()
         if custom_uploads:
             StorageExecution.iterate_resut(StorageExecution(), custom_uploads)
         else:
-            print 'Executing Custom upload retuned a None result'
+            print 'Executing %s upload retuned a None result' % self.storage_cmd.DESTINATION
+
+
+if __name__ == "__main__":
+
+    executor = StorageExecution()
+    executor.execute_upload()

--- a/nc-backup-py/storage/storage_templates.json
+++ b/nc-backup-py/storage/storage_templates.json
@@ -1,0 +1,28 @@
+{
+  "local" : {
+    "UPLOAD_COMMAND_TEMPLATE": "cp %(OBJECTIVES)s/%(file)s %(LOCAL_BACKUP)s/%(file)s",
+    "UPLOAD_COMMAND_DICT": "{'LOCAL_BACKUP': '/opt/backup/local'}",
+    "RM_COMMAND_TEMPLATE": "rm %(file)s",
+    "LS_COMMAND_TEMPLATE": "ls "
+  },
+  "s3" : {
+    "UPLOAD_COMMAND_TEMPLATE": "aws s3 cp %(OBJECTIVES)s/%(file)s s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
+    "UPLOAD_COMMAND_DICT": "{'BUCKET': 'ncbackup'}",
+    "RM_COMMAND_TEMPLATE": "aws s3 rm s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
+    "LS_COMMAND_TEMPLATE": "aws s3 ls s3://%(BUCKET)s/%(HOSTNAME)s/"
+  },
+  "oss" : {
+    "UPLOAD_COMMAND_TEMPLATE": "alicmd -u %(OBJECTIVES)s/%(file)s",
+    "UPLOAD_COMMAND_DICT": "",
+    "RM_COMMAND_TEMPLATE": "aws s3 rm s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
+    "LS_COMMAND_TEMPLATE": "aws s3 ls s3://%(BUCKET)s/%(HOSTNAME)s/"
+  },
+  "scp" : {
+    "UPLOAD_COMMAND_TEMPLATE": "scp -P %(PORT)s %(OBJECTIVES)s/%(file)s %(REMOTE_USER)s@%(REMOTE_HOST)s:%(REMOTE_DIR) ",
+    "UPLOAD_COMMAND_DICT": "{'PORT': '22', REMOTE_HOST:'localhost', 'REMOTE_USER': 'ncbackup', REMOTE_DIR: '/opt/storage'}",
+  },
+  "rsync" : {
+    "UPLOAD_COMMAND_TEMPLATE": "rsync -a  %(OBJECTIVES)s/%(file)s %(REMOTE_USER)s@%(REMOTE_HOST)s:%(PORT)s/%(REMOTE_DIR) ",
+    "UPLOAD_COMMAND_DICT": "{'PORT': '22', REMOTE_HOST:'localhost', 'REMOTE_USER': 'ncbackup', REMOTE_DIR: '/opt/storage'}",
+  }
+}

--- a/nc-backup-py/storage/storage_templates.json
+++ b/nc-backup-py/storage/storage_templates.json
@@ -14,8 +14,6 @@
   "oss" : {
     "UPLOAD_COMMAND_TEMPLATE": "alicmd -u %(OBJECTIVES)s/%(file)s",
     "UPLOAD_COMMAND_DICT": "",
-    "RM_COMMAND_TEMPLATE": "aws s3 rm s3://%(BUCKET)s/%(HOSTNAME)s/%(file)s",
-    "LS_COMMAND_TEMPLATE": "aws s3 ls s3://%(BUCKET)s/%(HOSTNAME)s/"
   },
   "scp" : {
     "UPLOAD_COMMAND_TEMPLATE": "scp -P %(PORT)s %(OBJECTIVES)s/%(file)s %(REMOTE_USER)s@%(REMOTE_HOST)s:%(REMOTE_DIR) ",

--- a/nc-backup-py/storage/storages.py
+++ b/nc-backup-py/storage/storages.py
@@ -7,6 +7,17 @@ from os.path import isfile, join
 from tools.filesystem_handling import remove_objectives
 
 class Storage:
+    """"""
+
+    def __init__(self, storage_cmd):
+        """Get and store arguments."""
+        self.__args = storage_cmd
+        self.__checkArgs()
+
+    def __checkArgs(self):
+        self.__custom_command_dict = eval(self.__args.ARGS_DICT)
+        self.__custom_command_dict["OBJECTIVES"] = self.__args.OBJECTIVES
+        self.__custom_command_dict["HOSTNAME"] = self.__args.HOSTNAME
 
     def list_content(self):
         print "Listing directory content"
@@ -20,223 +31,6 @@ class Storage:
     def check_size_content(self):
         print 'checking the files size'
 
-
-class AWSS3(Storage):
-    def __init__(self, home_path=''):
-        self.__home_path = home_path
-        # self.__subprocess_upload = SubprocessExecution()
-
-    def list_content(self):
-        print "Listing directory content"
-
-    @staticmethod
-    def test_aws_connectivity(home_path, bucket_name):
-        aws_s3_ls_command = 'aws s3 ls %s' % bucket_name
-        sys.path.append(home_path)
-        from execution.subprocess_execution import SubprocessExecution
-        result_aws_s3_ls = SubprocessExecution.main_execution_function(SubprocessExecution(), aws_s3_ls_command)
-        # print result_aws_s3_ls
-        # print type(result_aws_s3_ls[1])
-        # print bucket_name
-        # print result_aws_s3_ls[1].find(bucket_name)
-        # print type(result_aws_s3_ls[1].find(bucket_name))
-        # print result_aws_s3_ls[0]
-        if result_aws_s3_ls[0] == 255 and result_aws_s3_ls[1].find("Unable to locate credentials."):
-            return 'No credentials'
-        elif result_aws_s3_ls[0] == 255:
-            return 'Other error. Check if Bucket exists.'
-        return 'Ok'
-
-    def upload_content(self, mypath_to_dir, bucket, client_host_name, upload_command='aws s3 cp',
-                       remove_objective='False', aws_s3_test=True):
-        if upload_command is None:
-            upload_command = 'aws s3 cp'
-        aws_and_bucket_test = self.test_aws_connectivity(self.__home_path, bucket)
-        print aws_and_bucket_test
-        if aws_s3_test == True and aws_and_bucket_test == 'No credentials':
-            print 'The can not execute AWS CLI test; please check installation and credentials. ' \
-                  'Stopping execution of AWS upload'
-            exit(1)
-        elif aws_s3_test == True and aws_and_bucket_test == 'Bucket not Found':
-            print 'Can not find the AWS bucket name:'+ bucket +' Please check configs and try again'
-            exit(1)
-        print 'Uploading to storage S3'
-        files_to_upload = [f for f in listdir(mypath_to_dir) if isfile(join(mypath_to_dir, f))]
-        sys.path.append(self.__home_path)
-        from execution.subprocess_execution import SubprocessExecution
-        execution_message = []
-        for file_to_upload in files_to_upload:
-            aws_command = upload_command + ' '+ mypath_to_dir + '/' + file_to_upload + ' s3://'+ bucket + '/' \
-                          + client_host_name + '/' + file_to_upload
-            count = 1
-            time_retry = 60
-            while count <= 5:
-                print 'Trying upload attempt number: ' + str(count)
-                # try:
-                tmp_execution_message = SubprocessExecution.main_execution_function(SubprocessExecution(), aws_command)
-                # except
-                # print tmp_execution_message
-                time_retry = time_retry * count
-                if tmp_execution_message[0] == 0:
-                    print 'Upload attempt ' + str(count) + ' successful.'
-                    break
-                elif tmp_execution_message[0] == 127:
-                    print "Error with AWS CLI binary. Is it installed?"
-                    break
-                # NEED TO DETERMINE: is
-                # elif tmp_execution_message[0] == 1:
-                #     print "Error with AWS CLI binary. Is it installed?"
-                #     break
-                else:
-                    print 'Upload attempt number: ' + str(count) + ' FAILED for: ' + aws_command
-                    print 'StdOut: ' + str(tmp_execution_message[0])
-                    print 'StdErr: ' + str(tmp_execution_message[0])
-                    print 'We will wait for: ' + str(time_retry/60) + ' minute(s) before upload attempt number: ' + \
-                          str(count + 1)
-                    time.sleep(time_retry)
-                count = count + 1
-            execution_message.append(tmp_execution_message)
-
-        remove_objectives(mypath_to_dir, remove_objective)
-        return execution_message
-
-    def remove_content(self):
-        print 'S3: removing files from storage'
-
-    def check_size_content(self):
-        print 'checking the files size'
-
-class AliyunOSS(Storage):
-    def __init__(self, home_path=''):
-        self.__home_path = home_path
-
-        # self.__subprocess_upload = SubprocessExecution()
-
-    def list_content(self):
-        print "Listing directory content"
-
-    def upload_content(self, credentials_file, mypath_to_dir, bucket='', client_host_name='', remove_objective='False'):
-        print 'Trying uploading to Aliyun OSS bucket:'
-        if bucket is not None and bucket != '':
-            print bucket
-        files_to_upload = [f for f in listdir(mypath_to_dir) if isfile(join(mypath_to_dir, f))]
-        # import oss2
-        # credential_dict = self.__read_credentials_from_file(credentials_file)
-        # if bucket is not None and bucket != '':
-        #     credential_dict['bucket'] = bucket
-        # auth = oss2.Auth(credential_dict['access_id'], credential_dict['access_key'])
-        #
-        # bucket = oss2.Bucket(auth, credential_dict['host'], credential_dict['bucket'])
-        execution_message = []
-        sys.path.append(self.__home_path)
-        from execution.subprocess_execution import SubprocessExecution
-        for file_to_upload in files_to_upload:
-            tmp_result_execution = ''
-            local_file = mypath_to_dir + '/' + file_to_upload
-            # print local_file
-            count = 1
-            time_retry = 60
-            while count <= 5:
-                # try:
-                # print client_host_name + '/' + file_to_upload
-                alicmd_string = 'alicmd -u ' + local_file
-                # tmp_result_execution = bucket.put_object_from_file (client_host_name + '/' + file_to_upload, local_file)
-                # except:
-                #     print 'Attempt failed'
-                # print('status={0}, request_id={1}'.format(e.status, e.request_id))
-                tmp_execution_message = SubprocessExecution.main_execution_function(SubprocessExecution(), alicmd_string)
-
-                time_retry = time_retry * count
-                if tmp_execution_message[0] == 0:
-                    print 'Upload attempt ' + str(count) + ' successful.'
-                    break
-                elif tmp_execution_message[0] == 127:
-                    print "Error with AWS CLI binary. Is it installed?"
-                    break
-                # NEED TO DETERMINE: is
-                # elif tmp_execution_message[0] == 1:
-                #     print "Error with AWS CLI binary. Is it installed?"
-                #     break
-                else:
-                    print 'Upload attempt number: ' + str(count) + ' FAILED for: ' + aws_command
-                    print 'StdOut: ' + str(tmp_execution_message[0])
-                    print 'StdErr: ' + str(tmp_execution_message[0])
-                    print 'We will wait for: ' + str(time_retry/60) + ' minute(s) before upload attempt number: ' + \
-                          str(count + 1)
-                    time.sleep(time_retry)
-                # if tmp_result_execution and tmp_result_execution.status == 200:
-                #     message_return = 'Status: ' + str(tmp_result_execution.status) + ' Request ID: ' + \
-                #                      str(tmp_result_execution.request_id) + tmp_result_execution.etag
-                #     status_success = 0
-                #     print 'Upload attempt ' + str(count) + ' successful.'
-                #     break
-                # else:
-                #     status_success = 1
-                #     print 'Upload attempt number: ' + str(count) + ' FAILED for: ' + local_file
-                #     print tmp_result_execution
-                #     # print tmp_result_execution.headers
-                #     print 'We will wait for: ' + str(time_retry / 60) + ' minute(s) before upload attempt number: ' + \
-                #           str(count + 1)
-                #     time.sleep(time_retry)
-                count = count + 1
-            # execution_message.append((status_success, message_return, ''))
-            execution_message.append(tmp_execution_message)
-
-        sys.path.append(self.__home_path)
-        remove_objectives(mypath_to_dir, remove_objective)
-        return execution_message
-
-    def remove_content(self):
-        print 'S3: removing files from storage'
-
-
-    def check_size_content(self):
-        print 'checking the files size'
-
-    def __read_credentials_from_file(self, file_to_read):
-        print 'Now we read the Aliyun credentials from the file: ' + file_to_read
-        myvars = {}
-        with open(file_to_read, 'r') as file_loaded:
-            print file_loaded.name
-            for line in file_loaded:
-                if line  and line is not '' and '[' not in line and ']' not in line and not line.startswith('#'):
-                    name, var = line.partition("=")[::2]
-                    myvars[name.strip()] = str(var).strip().rstrip()
-        # print myvars
-        return myvars
-
-
-class SSHStorage(Storage):
-    def __init__(self, home_path=''):
-        self.__home_path = home_path
-
-    def upload_content(self, key_):
-        pass
-        """import scp
-
-            client = scp.Client(host=host, user=user, keyfile=keyfile)
-            # or
-            client = scp.Client(host=host, user=user)
-            client.use_system_keys()
-            # or
-            client = scp.Client(host=host, user=user, password=password)
-
-            # and then
-            client.transfer('/etc/local/filename', '/etc/remote/filename')
-        """
-
-class CustomCommand(Storage):
-
-    def __init__(self, storage_cmd):
-        """Get and store arguments."""
-        self.__args = storage_cmd
-        self.__checkArgs()
-
-    def __checkArgs(self):
-        self.__custom_command_dict = eval(self.__args.CUSTOM_COMMAND_DICT)
-        self.__custom_command_dict["OBJECTIVES"] = self.__args.OBJECTIVES
-        self.__custom_command_dict["HOSTNAME"] = self.__args.HOSTNAME
-
     def execute(self):
         from execution.subprocess_execution import SubprocessExecution
         files_to_upload = [f for f in listdir(self.__args.OBJECTIVES)
@@ -249,7 +43,7 @@ class CustomCommand(Storage):
 
             while count <= 5:
                 print 'Trying upload attempt number: ' + str(count)
-                command = self.__args.CUSTOM_COMMAND_TEMPLATE % self.__custom_command_dict
+                command = self.__args.UPLOAD_COMMAND_TEMPLATE % self.__custom_command_dict
                 print "Executing external command: %s " % command
                 tmp_execution_message = SubprocessExecution.main_execution_function(
                     SubprocessExecution(),


### PR DESCRIPTION
All upload commands are run using templates at "nc-backup-py/storage/storage_templates.json"

Tested local, oss, s3, scp and rsync along with qingcloud manually.

Support for new storage methods can be add by simply adding templates to "nc-backup-py/storage/storage_templates.json".

See docs(nc-backup-py/docs/STORAGE.md)

Need to add examples for ssh storage and rsync.

To-Do: List and remove (cleanup) functions are to be added.
