### PR TITLE
Use 'call_check' instead of 'Popen' to avoid blocked pipes and ignore tar returncode 1

### DIFF
--- a/nc-backup-py/execution/subprocess_execution.py
+++ b/nc-backup-py/execution/subprocess_execution.py
@@ -1,10 +1,5 @@
-from subprocess import Popen
-from subprocess import PIPE
-
-# from subprocess import check_output
-# from subprocess import call
-# from subprocess import CalledProcessError
-# from threading import Thread
+from subprocess import check_output
+from subprocess import CalledProcessError
 from Queue import Queue, Empty
 
 
@@ -22,11 +17,24 @@ class SubprocessExecution:
         else:
             print log_string
 
-        self.__process = Popen(shell_command, shell=True, stdout=PIPE, stderr=PIPE)
-        if wait_cmd is True:
-            self.__process.wait()
-        return_code = self.__process.poll()
-        stdout, stderr = self.__process.communicate()
+        return_code = 0
+        stdout = stderr = ''
+        try:
+            stdout = check_output(shell_command, shell=True)
+        except CalledProcessError as e:
+            return_code = e.returncode
+            stderr = e.output
+        # Debug return codes
+
+        # print("".center(79, '-'))
+        # print("stdout: %s " % stdout)
+        # print("type(stdout: %s " % type(stdout))
+        # print("stderr: %s " % stderr)
+        # print("type(stderr: %s " % type(stderr))
+        # print("return_code: %s " % return_code )
+        # print("type(return_code: %s " % type(return_code))
+        # print("".center(79, '-'))
+
         return return_code, stdout, 'stderr: ' + stderr
 
     def print_output(self, communicates_message):

--- a/nc-backup-py/filesbackup/filesbackup.py
+++ b/nc-backup-py/filesbackup/filesbackup.py
@@ -71,8 +71,10 @@ class FileBackups:
                         print 'Could Not create directory with command: ' + create_dir_cmd
                         print 'Error code: ' + str(execution_mkdir[0])
             execution_message = SubprocessExecution.main_execution_function(SubprocessExecution(), tar_command, True)
+            # tar exits with 1 if the file changed during the time we read it. Ignoring
+            # https://www.gnu.org/software/tar/manual/html_section/tar_19.html#Synopsis
             print execution_message
-            if execution_message [0] != 0:
+            if execution_message [0] not in [0, 1]:
                 print 'Executing the tar command: ' + tar_command
                 print 'Returned nor zero exit code: ' + str(execution_message[0],) + ', ' + str(execution_message[1]) + \
                       ', ' + str(execution_message[2])


### PR DESCRIPTION
1. Using Popen.wait() creates a deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data.

This deadlock happens once in a while on many servers during S3 upload. A lot of data is written to the stdout pipe (the uploading %). The pipe gets full and will block waiting for something to read.

Hence using subprocess.check_output and capturing stderr and returncodes from the exception raised by a failing subprocess.

https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

2. tar exits with 1 if the file changed during the time we read it. (for large and active files) Ignoring
https://www.gnu.org/software/tar/manual/html_section/tar_19.html#Synopsis